### PR TITLE
mensajes: llamar a `resize` dentro de `ScaleManager`

### DIFF
--- a/pilas-engine/mensajes.ts
+++ b/pilas-engine/mensajes.ts
@@ -139,6 +139,6 @@ class Mensajes {
 
   atender_mensaje_actualizar_proyecto_desde_el_editor(datos) {
     let proyecto = datos.proyecto;
-    this.pilas.game.resize(proyecto.ancho, proyecto.alto);
+    this.pilas.game.scale.resize(proyecto.ancho, proyecto.alto);
   }
 }

--- a/public/pilas-engine.js
+++ b/public/pilas-engine.js
@@ -637,7 +637,7 @@ var Mensajes = (function () {
     };
     Mensajes.prototype.atender_mensaje_actualizar_proyecto_desde_el_editor = function (datos) {
         var proyecto = datos.proyecto;
-        this.pilas.game.resize(proyecto.ancho, proyecto.alto);
+        this.pilas.game.scale.resize(proyecto.ancho, proyecto.alto);
     };
     return Mensajes;
 }());


### PR DESCRIPTION
Al compilar estaba dando el error:

```
make compilar_pilas
▷ Compilando pilas-engine
yarn compilar_pilas
yarn run v1.15.2
$ tsc -p pilas-engine --pretty -d
pilas-engine/mensajes.ts:142:21 - error TS2339: Property 'resize' does not exist on type 'Game'.

142     this.pilas.game.resize(proyecto.ancho, proyecto.alto);
                        ~~~~~~

Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Makefile:129: recipe for target 'compilar_pilas' failed
make: *** [compilar_pilas] Error 2
```