### PR TITLE
Actualiza la versión en el archivo appdata

### DIFF
--- a/extras/ar.com.pilas_engine.App.metainfo.xml
+++ b/extras/ar.com.pilas_engine.App.metainfo.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <component type="desktop">
   <id>ar.com.pilas_engine.App</id>
   <launchable type="desktop-id">ar.com.pilas_engine.App.desktop</launchable>
@@ -28,8 +28,9 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="2.7.3" date="2021-10-23"/>
-    <release version="2.7.4" date="2021-12-20"/>
+    <release version="2.7.3" date="2021-10-23" />
+    <release version="2.7.4" date="2021-12-20" />
+    <release version="2.8.15" date="2023-11-29" />
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="social-info">mild</content_attribute>

--- a/extras/ar.com.pilas_engine.App.metainfo.xml
+++ b/extras/ar.com.pilas_engine.App.metainfo.xml
@@ -29,6 +29,7 @@
   </screenshots>
   <releases>
     <release version="2.7.3" date="2021-10-23"/>
+    <release version="2.7.4" date="2021-12-20"/>
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="social-info">mild</content_attribute>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "compilar_bloques": "tsc -p bloques --pretty -d",
     "compilar_bloques_live": "tsc -p bloques --watch --pretty -d",
     "actualizar_actores": "node scripts/actualizar-actores.js",
-    "actualizar_actores_live": "node scripts/actualizar-actores-live.js"
+    "actualizar_actores_live": "node scripts/actualizar-actores-live.js",
+    "prepublish": "python3 scripts/actualizar_appdata.py"
   },
   "prettier": {
     "tabWidth": 2,

--- a/scripts/actualizar_appdata.py
+++ b/scripts/actualizar_appdata.py
@@ -1,0 +1,40 @@
+import json
+from datetime import datetime
+from xml.etree import ElementTree
+
+APPDATA_PATH = 'extras/ar.com.pilas_engine.App.metainfo.xml'
+
+
+def get_version_from_package_json():
+    with open('package.json') as f:
+        data = json.load(f)
+        return data['version']
+
+def get_version_date():
+    return datetime.today().strftime('%Y-%m-%d')
+
+def main():
+    new_version = get_version_from_package_json()
+
+    tree = ElementTree.parse(APPDATA_PATH)
+    root = tree.getroot()
+    releases = root.find('releases')
+
+    already_exists = False
+    for r in releases:
+        if r.attrib['version'] == new_version:
+            already_exists = True
+            break
+
+    if already_exists:
+        return
+
+    date = get_version_date()
+    ElementTree.SubElement(releases, 'release', { 'version': new_version, 'date': date })
+    ElementTree.indent(releases, level=1)
+
+    # ElementTree.dump(releases)
+    tree.write(APPDATA_PATH, encoding='utf-8', xml_declaration=True)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Idealmente habría que actualizar el XML de forma automática cada vez que se hace una nueva versión, antes de correr `ember release`. Por ejemplo se podría mantener un nuevo archivo de texto NEWS y usar el comando `appstreamcli news-to-metainfo`:

>   news-to-metainfo NEWS_FILE MI_FILE [OUT_FILE] - Convierte un archivo YAML o de texto NEWS en versiones de metainfo.

Por ahora, este PR actualiza el XML de forma manual.
