### PR TITLE
Agregar habilidad "seguir al (actor que tiene el) teclado"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ phaser
 /bower.json.ember-try
 /package.json.ember-try
 _book
+
+*~

--- a/app/components/pilas-propiedad/habilidades.js
+++ b/app/components/pilas-propiedad/habilidades.js
@@ -10,6 +10,7 @@ export default Component.extend({
       "moverse con el teclado",
       "seguir al mouse lentamente",
       "seguir al mouse",
+      "seguir al teclado",
       "oscilar verticalmente",
       "oscilar rotacion",
       "oscilar transparencia"

--- a/pilas-engine/habilidades.ts
+++ b/pilas-engine/habilidades.ts
@@ -3,6 +3,7 @@
 /// <reference path="habilidades/mover-con-el-teclado"/>
 /// <reference path="habilidades/seguir-al-mouse"/>
 /// <reference path="habilidades/seguir-al-mouse-lentamente"/>
+/// <reference path="habilidades/seguir-al-teclado"/>
 /// <reference path="habilidades/oscilar-verticalmente"/>
 /// <reference path="habilidades/oscilar-rotacion"/>
 /// <reference path="habilidades/oscilar-transparencia"/>
@@ -20,6 +21,7 @@ class Habilidades {
     this.vincular("mover con el teclado", MoverConElTeclado);
     this.vincular("seguir al mouse", SeguirAlMouse);
     this.vincular("seguir al mouse lentamente", SeguirAlMouseLentamente);
+    this.vincular("seguir al teclado", SeguirAlTeclado);
     this.vincular("oscilar verticalmente", OscilarVerticalmente);
     this.vincular("oscilar rotacion", OscilarRotacion);
     this.vincular("oscilar transparencia", OscilarTransparencia);

--- a/pilas-engine/habilidades/seguir-al-teclado.ts
+++ b/pilas-engine/habilidades/seguir-al-teclado.ts
@@ -1,0 +1,31 @@
+/// <reference path="-habilidad"/>
+
+class SeguirAlTeclado extends Habilidad {
+  actor_con_teclado: Actor;
+  
+  iniciar() {
+    let habilidad_teclado = this.pilas.habilidades.buscar("mover con el teclado").name;
+    let actores_con_teclado = this.pilas.obtener_actores().filter( a =>
+        a.tiene_habilidad(habilidad_teclado)
+    );
+    if(actores_con_teclado) {
+      this.actor_con_teclado = actores_con_teclado[0];
+    }else{
+      this.actor_con_teclado = null;
+    }
+  }
+
+  limitar(v: number): number {
+    return Math.max(-5, Math.min(5,v));
+  }
+
+  actualizar() {
+    if (this.actor_con_teclado) {
+      let destino_x = this.actor_con_teclado.x;
+      let destino_y = this.actor_con_teclado.y;
+
+      this.actor.x += this.limitar((destino_x - this.actor.x) / 10);
+      this.actor.y += this.limitar((destino_y - this.actor.y) / 10);
+    }
+  }
+}

--- a/public/pilas-engine.d.ts
+++ b/public/pilas-engine.d.ts
@@ -378,6 +378,12 @@ declare class SeguirAlMouseLentamente extends Habilidad {
     iniciar(): void;
     actualizar(): void;
 }
+declare class SeguirAlTeclado extends Habilidad {
+    actor_con_teclado: Actor;
+    iniciar(): void;
+    limitar(v: number): number;
+    actualizar(): void;
+}
 declare class OscilarVerticalmente extends Habilidad {
     contador: number;
     iniciar(): void;

--- a/public/pilas-engine.js
+++ b/public/pilas-engine.js
@@ -1721,6 +1721,36 @@ var SeguirAlMouseLentamente = (function (_super) {
     };
     return SeguirAlMouseLentamente;
 }(Habilidad));
+var SeguirAlTeclado = (function (_super) {
+    __extends(SeguirAlTeclado, _super);
+    function SeguirAlTeclado() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    SeguirAlTeclado.prototype.iniciar = function () {
+        var habilidad_teclado = this.pilas.habilidades.buscar("mover con el teclado").name;
+        var actores_con_teclado = this.pilas.obtener_actores().filter(function (a) {
+            return a.tiene_habilidad(habilidad_teclado);
+        });
+        if (actores_con_teclado) {
+            this.actor_con_teclado = actores_con_teclado[0];
+        }
+        else {
+            this.actor_con_teclado = null;
+        }
+    };
+    SeguirAlTeclado.prototype.limitar = function (v) {
+        return Math.max(-5, Math.min(5, v));
+    };
+    SeguirAlTeclado.prototype.actualizar = function () {
+        if (this.actor_con_teclado) {
+            var destino_x = this.actor_con_teclado.x;
+            var destino_y = this.actor_con_teclado.y;
+            this.actor.x += this.limitar((destino_x - this.actor.x) / 10);
+            this.actor.y += this.limitar((destino_y - this.actor.y) / 10);
+        }
+    };
+    return SeguirAlTeclado;
+}(Habilidad));
 var OscilarVerticalmente = (function (_super) {
     __extends(OscilarVerticalmente, _super);
     function OscilarVerticalmente() {
@@ -1772,6 +1802,7 @@ var Habilidades = (function () {
         this.vincular("mover con el teclado", MoverConElTeclado);
         this.vincular("seguir al mouse", SeguirAlMouse);
         this.vincular("seguir al mouse lentamente", SeguirAlMouseLentamente);
+        this.vincular("seguir al teclado", SeguirAlTeclado);
         this.vincular("oscilar verticalmente", OscilarVerticalmente);
         this.vincular("oscilar rotacion", OscilarRotacion);
         this.vincular("oscilar transparencia", OscilarTransparencia);


### PR DESCRIPTION
Esta habilidad permite hacer actores que persigan al actor manejado por los controles mas facilmente.

Es una aproximacion a la habilidad "PerseguirAOtroActor" de Pilas 1.