### PR TITLE
Ocultar menú de Electron

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -26,6 +26,7 @@ app.on("ready", function onReady() {
     height: 650,
     minWidth: 800,
     minHeight: 650,
+    autoHideMenuBar: true,
     webPreferences: {
       nodeIntegration: true,
       webSecurity: true


### PR DESCRIPTION
El menú que viene por defecto en Electron no proporciona nada relativo a Pilas Engine.

Por ejemplo, Help -> Documentation lleva a: https://github.com/electron/electron/tree/v9.1.0/docs#readme

Además está en inglés.

![Captura de pantalla de 2023-11-29 12-09-04](https://github.com/pilas-engine/pilas-engine/assets/83944/d738793c-cf12-4686-901e-d696cf909812)

