### PR TITLE
Sistema de rehacer, shortcuts y botones en la UI

### DIFF
--- a/app/components/pilas-editor.js
+++ b/app/components/pilas-editor.js
@@ -78,12 +78,13 @@ export default Component.extend({
       this.send("cuandoSelecciona", this.seleccion);
     }
 
-    document.addEventListener("keydown", this.alPulsarTecla.bind(this));
+    document.addEventListener("keydown", this.alPulsarTecla.bind(this), true);
 
     this.bus.trigger(`${this.nombre_del_contexto}:hacer_foco_en_pilas`, {});
     this.instanciarSplitJS();
 
     this.capturar_ctrl_s();
+    this.capturar_ctrl_z_y();
   },
 
   capturar_ctrl_s() {
@@ -103,7 +104,36 @@ export default Component.extend({
           e.stopPropagation();
           break;
       }
-    });
+    }, true);
+  },
+
+  capturar_ctrl_z_y() {
+    document.addEventListener("keydown", e => {
+      e = e || window.event;
+
+      if (!e.ctrlKey && !e.metaKey) {
+        return;
+      }
+
+      var code = e.which || e.keyCode;
+
+      switch (code) {
+        case 90:
+          if (e.shiftKey) {
+            this.send("rehacer");
+          } else {
+            this.send("deshacer");
+          }
+          e.preventDefault();
+          e.stopPropagation();
+          break;
+        case 89:
+          this.send("rehacer");
+          e.preventDefault();
+          e.stopPropagation();
+          break;
+      }
+    }, true);
   },
 
   instanciarSplitJS() {
@@ -923,6 +953,10 @@ export default Component.extend({
 
     deshacer() {
       this.memento.deshacer(this);
+    },
+
+    rehacer() {
+      this.memento.rehacer(this);
     },
 
     cambiarPosicion(valorNuevo) {

--- a/app/services/memento.js
+++ b/app/services/memento.js
@@ -1,6 +1,7 @@
 import Service from "@ember/service";
 import { computed } from "@ember/object";
 import { inject as service } from "@ember/service";
+import copiar from "../utils/copiar";
 
 const LIMITE = 10;
 
@@ -12,6 +13,7 @@ export default Service.extend({
 
   iniciar() {
     this.set("historial", []);
+    this.set("pila_de_rehacer", []);
     window.memento = this;
 
     this.set("ultima_llamada", new Date());
@@ -25,12 +27,17 @@ export default Service.extend({
     return this.pasos > 0;
   }),
 
+  puede_rehacer: computed("pila_de_rehacer.length", function() {
+    return this.get("pila_de_rehacer.length") > 0;
+  }),
+
   accion(nombre, datos) {
     if (this.pasos >= LIMITE) {
       this.historial.removeAt(0);
     }
 
     this.historial.pushObject({ nombre, datos });
+    this.set("pila_de_rehacer", []);
     this.registrar_ultima_accion(nombre);
   },
 
@@ -49,13 +56,68 @@ export default Service.extend({
   deshacer(editor) {
     let paso = this.historial.popObject();
 
+    if (!paso) {
+      return;
+    }
+
     if (this.historial.lastObject) {
       this.registrar_ultima_accion(this.historial.lastObject.nombre);
     } else {
       this.set("ultima_accion", "");
     }
 
+    let paso_para_rehacer = this.crear_paso_inverso(paso, editor);
+    this.pila_de_rehacer.pushObject(paso_para_rehacer);
     this.aplicar_paso_de_memento(paso, editor);
+  },
+
+  rehacer(editor) {
+    let paso = this.pila_de_rehacer.popObject();
+
+    if (!paso) {
+      return;
+    }
+
+    let paso_para_deshacer = this.crear_paso_inverso(paso, editor);
+    this.historial.pushObject(paso_para_deshacer);
+    this.registrar_ultima_accion(paso.nombre);
+    this.aplicar_paso_de_memento(paso, editor);
+  },
+
+  crear_paso_inverso(paso, editor) {
+    let escena;
+    let actor;
+
+    switch (paso.nombre) {
+      case "mueve_actor":
+        escena = editor.obtener_la_escena_actual();
+        actor = escena.actores.findBy("id", paso.datos.id);
+        return { nombre: "mueve_actor", datos: { id: paso.datos.id, x: actor.x, y: actor.y } };
+
+      case "agrega_actor": {
+        escena = editor.obtener_la_escena_actual();
+        actor = escena.actores.findBy("id", paso.datos.id);
+        let codigo = editor.proyecto.codigos.actores.findBy("nombre", actor.nombre);
+        return { nombre: "elimina_actor", datos: { actor: { nombre: actor.nombre, codigo: copiar(codigo.codigo), imagen: actor.imagen, propiedades: copiar(actor) }, id: paso.datos.id } };
+      }
+
+      case "elimina_actor":
+        return { nombre: "agrega_actor", datos: { id: paso.datos.id } };
+
+      case "propiedad_de_actor":
+        escena = editor.obtener_la_escena_actual();
+        actor = escena.actores.findBy("id", paso.datos.id);
+        return { nombre: "propiedad_de_actor", datos: { id: paso.datos.id, propiedad: paso.datos.propiedad, valor: actor.get(paso.datos.propiedad) } };
+
+      case "cambia_actor_de_escena":
+        return { nombre: "cambia_actor_de_escena", datos: { id: paso.datos.id, escena_anterior: paso.datos.escena_nueva, escena_nueva: paso.datos.escena_anterior } };
+
+      case "cambia_actor_de_carpeta":
+        return { nombre: "cambia_actor_de_carpeta", datos: { id: paso.datos.id, carpeta_anterior: paso.datos.carpeta_nueva, carpeta_nueva: paso.datos.carpeta_anterior } };
+
+      default:
+        throw Error(`Caso no contemplado para crear_paso_inverso: ${paso.nombre}`);
+    }
   },
 
   aplicar_paso_de_memento(paso, editor) {
@@ -126,6 +188,7 @@ export default Service.extend({
 
   limpiar() {
     this.set("historial", []);
+    this.set("pila_de_rehacer", []);
   },
 
   registrar_ultima_accion(nombre) {

--- a/app/templates/components/pilas-botones-para-deshacer-y-rehacer.hbs
+++ b/app/templates/components/pilas-botones-para-deshacer-y-rehacer.hbs
@@ -4,4 +4,10 @@
       {{pilas-mini-icono icono="undo"}}
     {{/pilas-boton-miniatura-pulsable}}
   {{/pilas-tooltip}}
+
+  {{#pilas-tooltip class="right-1 w4" texto=(concat (concat (t "redo") " ") memento.ultima_accion)}}
+    {{#pilas-boton-miniatura-pulsable desactivado=(not memento.puede_rehacer) class="f7 texto pr2" accion=rehacer}}
+      {{pilas-mini-icono icono="redo"}}
+    {{/pilas-boton-miniatura-pulsable}}
+  {{/pilas-tooltip}}
 </div>

--- a/app/templates/components/pilas-editor-panel-de-juego-con-canvas.hbs
+++ b/app/templates/components/pilas-editor-panel-de-juego-con-canvas.hbs
@@ -2,7 +2,7 @@
 
   <div class="separador-vertical flex">
 
-    {{pilas-botones-para-deshacer-y-rehacer estado=estado deshacer=deshacer}}
+    {{pilas-botones-para-deshacer-y-rehacer estado=estado deshacer=deshacer rehacer=rehacer}}
 
     <div class="flex1">
     </div>

--- a/app/templates/components/pilas-editor.hbs
+++ b/app/templates/components/pilas-editor.hbs
@@ -78,6 +78,7 @@
         zoom=zoom
         modoZoom=modoZoom
         deshacer=(action "deshacer")
+        rehacer=(action "rehacer")
         detener=(action "detener")
         detener_y_volver_al_editor=(action "detener_y_volver_al_editor")
         existe_un_error_reciente=existe_un_error_reciente

--- a/app/templates/components/pilas-mini-icono.hbs
+++ b/app/templates/components/pilas-mini-icono.hbs
@@ -34,6 +34,10 @@
   <svg fill="currentColor" class="icono-boton" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
     <path d="M15 17v-2.99A4 4 0 0 0 11 10H8v5L2 9l6-6v5h3a6 6 0 0 1 6 6v3h-2z"/>
   </svg>
+{{else if (eq icono "redo")}}
+  <svg fill="currentColor" class="icono-boton" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+    <path d="M5 17v-2.99A4 4 0 0 1 9 10h3v5l6-6-6-6v5H9a6 6 0 0 0-6 6v3h2z"/>
+  </svg>
 {{else if (eq icono "actualizada")}}
   <svg fill="currentColor" class="icono-boton" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
     <path d="M0 11l2-2 5 5L18 3l2 2L7 18z"/>

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -249,6 +249,7 @@ server:
   start: Start web server
 
 undo: Undo
+redo: Redo
 only.pilas.files: You can only open .pilas files
 
 iniciar.proyecto:

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -248,6 +248,7 @@ server:
   start: Iniciar servidor web
 
 undo: Deshacer
+redo: Rehacer
 only.pilas.files: Solo puede abrir archivos con extensión .pilas
 
 iniciar.proyecto:

--- a/translations/zh.yaml
+++ b/translations/zh.yaml
@@ -245,6 +245,7 @@ server:
   start: 启动Web服务器
 
 undo: 撤消
+redo: 重做
 only.pilas.files: 您只能打开.pilas文件
 
 iniciar.proyecto:


### PR DESCRIPTION
El editor solo tenía un botón de deshacer, sin atajos de teclado ni rehacer. Agregué un botón de rehacer junto al de deshacer, atajos de teclado Ctrl+Z/Ctrl+Y con soporte macOS, la lógica de rehacer en el servicio memento con pila de rehacer que se limpia al registrar una nueva acción, el ícono SVG redo y las traducciones correspondientes.

<img width="194" height="110" alt="image" src="https://github.com/user-attachments/assets/a977bbf2-a1b8-49bf-a181-55c299715102" />