### PR TITLE
Actualización de documentación: requerimiento de Node 12

### DIFF
--- a/manual/entorno.md
+++ b/manual/entorno.md
@@ -31,7 +31,7 @@ Estos son los archivos principales del repositorio y qué función cumplen:
 
 ## Repositorio y modelo de trabajo
 
-Antes de iniciar, necesitas tener instalado NodeJS 8 y el gestor de paquetes "yarn".
+Antes de iniciar, necesitas tener instalado NodeJS 12 (12.22.12 es la última versión estable) y el gestor de paquetes "yarn". Es importante tener activa la versión de node 12 antes de instalar "yarn".
 
 Si quieres asegurarte de tener todo correctamente instalado escribí los siguientes comandos:
 


### PR DESCRIPTION
El manual señalaba que la versión requerida para el entorno de Pilas era NodeJS 8, pero en realidad se precisa la versión 12. También se aclara que podría haber problemas si se instala yarn, vía npm, desde una versión de node diferente a la 12.